### PR TITLE
remove unused route

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,7 @@ async fn main() {
 
     let state = scheduler::SchedulerState::new();
 
-    // build our application with a route
     let app = Router::new()
-        // `GET /` goes to `root`
-        .route("/", get(root))
-        // `POST /users` goes to `create_user`
         .route("/judge", post(create_judge).get(get_judges))
         .route("/item", post(create_item).get(get_items))
         .route("/scheduler_start", post(start_matchmaking))
@@ -38,11 +34,6 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", addr);
-}
-
-// basic handler that responds with a static string
-async fn root() -> &'static str {
-    "Hello, World!"
 }
 
 async fn get_judges(


### PR DESCRIPTION
### TL;DR

Removed the root endpoint and its associated handler function from the API

### What changed?

- Removed the `GET /` route and its corresponding `root()` handler function
- Cleaned up route declarations by removing redundant comments

### How to test?

1. Start the server
2. Verify that accessing the root endpoint (`GET /`) returns a 404
3. Confirm all other endpoints (`/judge`, `/item`, `/scheduler_start`) continue to function as expected

### Why make this change?

The root endpoint was only returning a static "Hello, World!" message and served no functional purpose in the application. Removing it helps maintain a cleaner API surface that better reflects the actual functionality of the service.