### PR TITLE
better error msg

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -340,7 +340,7 @@ impl SchedulerState {
                 Some(Err(Box::new(SchedulerError::new("Match key not found"))))
             }
         } else {
-            Some(Err(Box::new(SchedulerError::new("Could not peek queue"))))
+            Some(Err(Box::new(SchedulerError::new("Queue peak failed!"))))
         }
     }
 


### PR DESCRIPTION
### TL;DR
Updated error message for queue peek failure to be more specific

### What changed?
Modified the error message from "Could not peek queue" to "Queue peak failed!" to provide a more direct indication of the failure

### How to test?
1. Attempt to peek an empty or invalid queue
2. Verify the new error message is displayed when the operation fails

### Why make this change?
The new error message is more explicit about the specific operation that failed, making it easier to identify and debug queue-related issues